### PR TITLE
Add modern counter web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Moderner Zähler
+
+Eine minimalistische, moderne Webanwendung, die eine Zahl in der Mitte des Bildschirms
+anzeigt. Jeder Klick auf den Button erhöht die Zahl um eins.
+
+## Nutzung
+
+Öffne die Datei `index.html` in einem aktuellen Browser oder starte einen einfachen
+HTTP-Server, z. B. mit Python:
+
+```bash
+python -m http.server 8000
+```
+
+Rufe anschließend [http://localhost:8000](http://localhost:8000) im Browser auf.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # Moderner Zähler
 
-Eine minimalistische, moderne Webanwendung, die eine Zahl in der Mitte des Bildschirms
-anzeigt. Jeder Klick auf den Button erhöht die Zahl um eins.
+Eine minimalistische Webanwendung, die eine Zahl in der Mitte des Bildschirms
+anzeigt. Jeder Klick oder Tastendruck (Enter oder Leertaste) erhöht die Zahl um
+Eins.
 
 ## Nutzung
 
-Öffne die Datei `index.html` in einem aktuellen Browser oder starte einen einfachen
-HTTP-Server, z. B. mit Python:
+Öffne die Datei `index.html` in einem aktuellen Browser oder starte einen
+einfachen HTTP-Server, z. B. mit Python:
 
 ```bash
 python -m http.server 8000

--- a/index.html
+++ b/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Moderner Zähler</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="app" role="main">
+      <h1 class="app__title">Moderner Zähler</h1>
+      <p class="app__subtitle">
+        Klicke auf den Button, um die Zahl in der Mitte zu erhöhen.
+      </p>
+      <div class="counter" aria-live="polite">
+        <span id="counterValue" class="counter__value">0</span>
+      </div>
+      <button id="incrementButton" class="button" type="button">
+        Zahl erhöhen
+      </button>
+    </main>
+    <script type="module" src="script.js"></script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -8,15 +8,14 @@
   </head>
   <body>
     <main class="app" role="main">
-      <h1 class="app__title">Moderner Zähler</h1>
-      <p class="app__subtitle">
-        Klicke auf den Button, um die Zahl in der Mitte zu erhöhen.
-      </p>
-      <div class="counter" aria-live="polite">
-        <span id="counterValue" class="counter__value">0</span>
-      </div>
+      <section class="display" aria-live="polite">
+        <h1 class="display__label">Zählerstand</h1>
+        <output id="counterValue" class="display__value" aria-atomic="true" for="incrementButton">
+          0
+        </output>
+      </section>
       <button id="incrementButton" class="button" type="button">
-        Zahl erhöhen
+        +1 hinzufügen
       </button>
     </main>
     <script type="module" src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -9,9 +9,22 @@ const updateCounter = () => {
   counterValueEl.textContent = formatNumber.format(counter);
 };
 
-incrementButton.addEventListener('click', () => {
+const increment = () => {
   counter += 1;
   updateCounter();
+};
+
+incrementButton.addEventListener('click', increment);
+
+document.addEventListener('keydown', (event) => {
+  const isSpace = event.code === 'Space';
+  const isEnter = event.code === 'Enter';
+
+  if ((isSpace || isEnter) && !event.repeat) {
+    event.preventDefault();
+    incrementButton.focus();
+    increment();
+  }
 });
 
 updateCounter();

--- a/script.js
+++ b/script.js
@@ -1,0 +1,17 @@
+const counterValueEl = document.querySelector('#counterValue');
+const incrementButton = document.querySelector('#incrementButton');
+
+let counter = 0;
+
+const formatNumber = new Intl.NumberFormat('de-DE');
+
+const updateCounter = () => {
+  counterValueEl.textContent = formatNumber.format(counter);
+};
+
+incrementButton.addEventListener('click', () => {
+  counter += 1;
+  updateCounter();
+});
+
+updateCounter();

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,98 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Inter", "Helvetica Neue", system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", sans-serif;
+  background-color: #0f172a;
+  color: #e2e8f0;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: radial-gradient(circle at top, rgba(59, 130, 246, 0.4), transparent 55%),
+    radial-gradient(circle at bottom, rgba(236, 72, 153, 0.35), transparent 50%),
+    #0f172a;
+}
+
+.app {
+  text-align: center;
+  padding: 3rem clamp(1.5rem, 2.5vw, 3rem);
+  border-radius: 24px;
+  backdrop-filter: blur(12px);
+  background: rgba(15, 23, 42, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: 0 30px 60px rgba(15, 23, 42, 0.45);
+  max-width: 420px;
+  width: min(90vw, 420px);
+}
+
+.app__title {
+  font-size: clamp(2rem, 5vw, 2.8rem);
+  margin: 0 0 0.75rem;
+}
+
+.app__subtitle {
+  margin: 0 0 2rem;
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.counter {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: clamp(180px, 30vw, 220px);
+  margin-bottom: 2.5rem;
+  border-radius: 20px;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.35), rgba(236, 72, 153, 0.35));
+  border: 1px solid rgba(148, 163, 184, 0.3);
+}
+
+.counter__value {
+  font-size: clamp(3rem, 12vw, 6rem);
+  font-weight: 700;
+  letter-spacing: 0.05em;
+}
+
+.button {
+  font-size: 1.1rem;
+  font-weight: 600;
+  padding: 0.95rem 2.5rem;
+  border-radius: 999px;
+  border: none;
+  cursor: pointer;
+  color: #0f172a;
+  background: linear-gradient(135deg, #38bdf8, #6366f1);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 15px 30px rgba(99, 102, 241, 0.35);
+}
+
+.button:focus-visible {
+  outline: 3px solid rgba(56, 189, 248, 0.7);
+  outline-offset: 3px;
+}
+
+.button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 20px 40px rgba(99, 102, 241, 0.45);
+}
+
+.button:active {
+  transform: translateY(1px);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/styles.css
+++ b/styles.css
@@ -1,9 +1,8 @@
 :root {
-  color-scheme: light dark;
+  color-scheme: dark light;
   font-family: "Inter", "Helvetica Neue", system-ui, -apple-system, BlinkMacSystemFont,
     "Segoe UI", sans-serif;
-  background-color: #0f172a;
-  color: #e2e8f0;
+  font-size: 16px;
 }
 
 * {
@@ -15,75 +14,86 @@ body {
   min-height: 100vh;
   display: grid;
   place-items: center;
-  background: radial-gradient(circle at top, rgba(59, 130, 246, 0.4), transparent 55%),
-    radial-gradient(circle at bottom, rgba(236, 72, 153, 0.35), transparent 50%),
+  background: radial-gradient(circle at top left, #14b8a6 0%, transparent 55%),
+    radial-gradient(circle at bottom right, #6366f1 0%, transparent 50%),
     #0f172a;
+  color: #e2e8f0;
 }
 
 .app {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2.5rem;
   text-align: center;
-  padding: 3rem clamp(1.5rem, 2.5vw, 3rem);
-  border-radius: 24px;
-  backdrop-filter: blur(12px);
-  background: rgba(15, 23, 42, 0.7);
+  padding: clamp(2rem, 5vw, 3rem);
+  border-radius: 28px;
+  background: rgba(15, 23, 42, 0.75);
   border: 1px solid rgba(148, 163, 184, 0.25);
-  box-shadow: 0 30px 60px rgba(15, 23, 42, 0.45);
-  max-width: 420px;
+  box-shadow: 0 40px 80px rgba(15, 23, 42, 0.55);
   width: min(90vw, 420px);
 }
 
-.app__title {
-  font-size: clamp(2rem, 5vw, 2.8rem);
-  margin: 0 0 0.75rem;
+.display {
+  display: grid;
+  gap: 1rem;
 }
 
-.app__subtitle {
-  margin: 0 0 2rem;
+.display__label {
+  font-size: clamp(1.1rem, 2.4vw, 1.5rem);
+  font-weight: 600;
   color: rgba(226, 232, 240, 0.75);
+  margin: 0;
 }
 
-.counter {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  height: clamp(180px, 30vw, 220px);
-  margin-bottom: 2.5rem;
-  border-radius: 20px;
-  background: linear-gradient(135deg, rgba(59, 130, 246, 0.35), rgba(236, 72, 153, 0.35));
-  border: 1px solid rgba(148, 163, 184, 0.3);
-}
-
-.counter__value {
-  font-size: clamp(3rem, 12vw, 6rem);
+.display__value {
+  display: grid;
+  place-items: center;
+  font-size: clamp(3.5rem, 12vw, 6.5rem);
   font-weight: 700;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.06em;
+  height: clamp(180px, 35vw, 240px);
+  border-radius: 24px;
+  background: linear-gradient(135deg, rgba(20, 184, 166, 0.25), rgba(99, 102, 241, 0.25));
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  margin: 0;
 }
 
 .button {
   font-size: 1.1rem;
   font-weight: 600;
-  padding: 0.95rem 2.5rem;
+  padding: 1rem 3rem;
   border-radius: 999px;
   border: none;
   cursor: pointer;
   color: #0f172a;
-  background: linear-gradient(135deg, #38bdf8, #6366f1);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-  box-shadow: 0 15px 30px rgba(99, 102, 241, 0.35);
-}
-
-.button:focus-visible {
-  outline: 3px solid rgba(56, 189, 248, 0.7);
-  outline-offset: 3px;
+  background: linear-gradient(135deg, #22d3ee, #a855f7);
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+  box-shadow: 0 20px 45px rgba(168, 85, 247, 0.45);
 }
 
 .button:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 20px 40px rgba(99, 102, 241, 0.45);
+  transform: translateY(-3px);
+  box-shadow: 0 30px 60px rgba(168, 85, 247, 0.45);
 }
 
 .button:active {
   transform: translateY(1px);
+}
+
+.button:focus-visible {
+  outline: 3px solid rgba(34, 211, 238, 0.8);
+  outline-offset: 4px;
+}
+
+@media (max-width: 480px) {
+  .app {
+    gap: 2rem;
+  }
+
+  .button {
+    width: 100%;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Summary
- add a modern single-page counter experience with a button that increments the number
- style the layout with gradients, focus states, and responsive typography
- document how to launch the page via a simple static server

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68e63517e618832d9fe8f328e5336196