### PR TITLE
Handle upload errors with structured JSON

### DIFF
--- a/upload.php
+++ b/upload.php
@@ -1,7 +1,26 @@
 <?php
 header('Content-Type: application/json; charset=utf-8');
 
-$uploadDir = __DIR__ . DIRECTORY_SEPARATOR . 'originale' . DIRECTORY_SEPARATOR;
+class HttpException extends RuntimeException
+{
+    public function __construct(string $message, private readonly int $statusCode = 500, ?Throwable $previous = null)
+    {
+        parent::__construct($message, 0, $previous);
+    }
+
+    public function getStatusCode(): int
+    {
+        return $this->statusCode;
+    }
+}
+
+set_error_handler(static function (int $severity, string $message, string $file, int $line): bool {
+    if (!(error_reporting() & $severity)) {
+        return false;
+    }
+
+    throw new ErrorException($message, 0, $severity, $file, $line);
+});
 
 $respond = static function (array $payload, int $statusCode = 200): void {
     http_response_code($statusCode);
@@ -9,119 +28,119 @@ $respond = static function (array $payload, int $statusCode = 200): void {
     exit;
 };
 
-if (!file_exists($uploadDir)) {
-    if (!mkdir($uploadDir, 0755, true) && !is_dir($uploadDir)) {
-        $respond([
-            'success' => false,
-            'error' => 'Upload-Verzeichnis konnte nicht erstellt werden.'
-        ], 500);
+$uploadDir = __DIR__ . DIRECTORY_SEPARATOR . 'originale' . DIRECTORY_SEPARATOR;
+
+try {
+    if (!file_exists($uploadDir)) {
+        if (!mkdir($uploadDir, 0755, true) && !is_dir($uploadDir)) {
+            throw new HttpException('Upload-Verzeichnis konnte nicht erstellt werden.', 500);
+        }
     }
-}
 
-if (!isset($_FILES['image']) || !is_uploaded_file($_FILES['image']['tmp_name'])) {
-    $respond([
-        'success' => false,
-        'error' => 'Keine Datei empfangen.'
-    ], 400);
-}
+    if (!isset($_FILES['image']) || !is_uploaded_file($_FILES['image']['tmp_name'])) {
+        throw new HttpException('Keine Datei empfangen.', 400);
+    }
 
-$file = $_FILES['image'];
+    $file = $_FILES['image'];
 
-if ($file['error'] !== UPLOAD_ERR_OK) {
-    $respond([
-        'success' => false,
-        'error' => 'Fehler beim Upload: ' . $file['error']
-    ], 400);
-}
+    if (($file['error'] ?? UPLOAD_ERR_OK) !== UPLOAD_ERR_OK) {
+        throw new HttpException('Fehler beim Upload: ' . ($file['error'] ?? 'unbekannt'), 400);
+    }
 
-$allowedMime = ['image/jpeg', 'image/png', 'image/gif', 'image/webp', 'image/svg+xml'];
+    $allowedMime = ['image/jpeg', 'image/png', 'image/gif', 'image/webp', 'image/svg+xml'];
 
-$finfo = finfo_open(FILEINFO_MIME_TYPE);
-$mimeType = finfo_file($finfo, $file['tmp_name']);
-finfo_close($finfo);
+    $finfo = finfo_open(FILEINFO_MIME_TYPE);
+    if ($finfo === false) {
+        throw new HttpException('Datei-Info konnte nicht gelesen werden.', 500);
+    }
 
-if (!in_array($mimeType, $allowedMime, true)) {
-    $respond([
-        'success' => false,
-        'error' => 'Nur Bilddateien sind erlaubt.'
-    ], 400);
-}
+    $mimeType = finfo_file($finfo, $file['tmp_name']);
+    finfo_close($finfo);
 
-$originalName = $file['name'] ?? 'upload';
-$sanitized = preg_replace('/[\\\/\x00-\x1F\x7F]+/u', '_', $originalName);
-$sanitized = trim($sanitized);
-$sanitized = $sanitized === '' ? 'upload_' . date('Ymd_His') : $sanitized;
-$storedName = basename($sanitized);
+    if (!in_array($mimeType, $allowedMime, true)) {
+        throw new HttpException('Nur Bilddateien sind erlaubt.', 400);
+    }
 
-$destination = $uploadDir . $storedName;
+    $originalName = $file['name'] ?? 'upload';
+    $sanitized = preg_replace('/[\\\/\x00-\x1F\x7F]+/u', '_', $originalName);
+    $sanitized = trim((string) $sanitized);
+    $sanitized = $sanitized === '' ? 'upload_' . date('Ymd_His') : $sanitized;
+    $storedName = basename($sanitized);
 
-$nameWithoutExtension = pathinfo($storedName, PATHINFO_FILENAME);
-$extension = pathinfo($storedName, PATHINFO_EXTENSION);
-$extensionWithDot = $extension !== '' ? '.' . $extension : '';
-$counter = 1;
-while (file_exists($destination)) {
-    $storedName = sprintf('%s_%d%s', $nameWithoutExtension, $counter, $extensionWithDot);
     $destination = $uploadDir . $storedName;
-    $counter++;
-}
 
-if (!move_uploaded_file($file['tmp_name'], $destination)) {
-    $respond([
-        'success' => false,
-        'error' => 'Datei konnte nicht gespeichert werden.'
-    ], 500);
-}
-
-$forwardUrl = 'https://tex305agency.app.n8n.cloud/webhook-test/a73c04f0-5a11-40e5-956a-b0aa2c4d34c5';
-
-$curlFile = curl_file_create($destination, $mimeType, $storedName);
-$ch = curl_init($forwardUrl);
-curl_setopt_array($ch, [
-    CURLOPT_POST => true,
-    CURLOPT_POSTFIELDS => ['image' => $curlFile],
-    CURLOPT_RETURNTRANSFER => true,
-    CURLOPT_HTTPHEADER => ['Accept: application/json, */*;q=0.8'],
-    CURLOPT_CONNECTTIMEOUT => 10,
-    CURLOPT_TIMEOUT => 30,
-]);
-
-$forwardResponse = curl_exec($ch);
-$forwardStatus = curl_getinfo($ch, CURLINFO_RESPONSE_CODE) ?: null;
-$curlError = null;
-
-if ($forwardResponse === false) {
-    $curlError = curl_error($ch) ?: 'Unbekannter Fehler bei der Weiterleitung.';
-}
-
-curl_close($ch);
-
-$parsedForwardResponse = null;
-if ($forwardResponse !== false) {
-    $decoded = json_decode($forwardResponse, true);
-    if (json_last_error() === JSON_ERROR_NONE) {
-        $parsedForwardResponse = $decoded;
-    } else {
-        $parsedForwardResponse = $forwardResponse;
+    $nameWithoutExtension = pathinfo($storedName, PATHINFO_FILENAME);
+    $extension = pathinfo($storedName, PATHINFO_EXTENSION);
+    $extensionWithDot = $extension !== '' ? '.' . $extension : '';
+    $counter = 1;
+    while (file_exists($destination)) {
+        $storedName = sprintf('%s_%d%s', $nameWithoutExtension, $counter, $extensionWithDot);
+        $destination = $uploadDir . $storedName;
+        $counter++;
     }
-}
 
-$urlPath = 'originale/' . $storedName;
+    if (!move_uploaded_file($file['tmp_name'], $destination)) {
+        throw new HttpException('Datei konnte nicht gespeichert werden.', 500);
+    }
 
-if ($curlError !== null) {
+    $forwardUrl = 'https://tex305agency.app.n8n.cloud/webhook-test/a73c04f0-5a11-40e5-956a-b0aa2c4d34c5';
+
+    $curlFile = curl_file_create($destination, $mimeType, $storedName);
+    $ch = curl_init($forwardUrl);
+    if ($ch === false) {
+        throw new HttpException('Weiterleitungs-Client konnte nicht initialisiert werden.', 500);
+    }
+
+    curl_setopt_array($ch, [
+        CURLOPT_POST => true,
+        CURLOPT_POSTFIELDS => ['image' => $curlFile],
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_HTTPHEADER => ['Accept: application/json, */*;q=0.8'],
+        CURLOPT_CONNECTTIMEOUT => 10,
+        CURLOPT_TIMEOUT => 30,
+    ]);
+
+    $forwardResponse = curl_exec($ch);
+    $forwardStatus = curl_getinfo($ch, CURLINFO_RESPONSE_CODE) ?: null;
+    $curlError = null;
+
+    if ($forwardResponse === false) {
+        $curlError = curl_error($ch) ?: 'Unbekannter Fehler bei der Weiterleitung.';
+    }
+
+    curl_close($ch);
+
+    if ($curlError !== null) {
+        throw new HttpException('Weiterleitung fehlgeschlagen: ' . $curlError, 502);
+    }
+
+    $parsedForwardResponse = null;
+    if ($forwardResponse !== false) {
+        $decoded = json_decode($forwardResponse, true);
+        if (json_last_error() === JSON_ERROR_NONE) {
+            $parsedForwardResponse = $decoded;
+        } else {
+            $parsedForwardResponse = $forwardResponse;
+        }
+    }
+
+    $urlPath = 'originale/' . $storedName;
+
     $respond([
-        'success' => false,
-        'error' => 'Weiterleitung fehlgeschlagen: ' . $curlError,
+        'success' => true,
+        'message' => 'Upload erfolgreich gespeichert und weitergeleitet.',
         'url' => $urlPath,
         'name' => $storedName,
         'forward_status' => $forwardStatus,
-    ], 502);
-}
+        'forward_response' => $parsedForwardResponse,
+    ]);
+} catch (Throwable $exception) {
+    $statusCode = $exception instanceof HttpException ? $exception->getStatusCode() : 500;
 
-$respond([
-    'success' => true,
-    'message' => 'Upload erfolgreich gespeichert und weitergeleitet.',
-    'url' => $urlPath,
-    'name' => $storedName,
-    'forward_status' => $forwardStatus,
-    'forward_response' => $parsedForwardResponse,
-]);
+    $respond([
+        'success' => false,
+        'message' => $exception->getMessage(),
+    ], $statusCode);
+} finally {
+    restore_error_handler();
+}


### PR DESCRIPTION
## Summary
- wrap the upload flow in a try/catch block and convert PHP warnings into exceptions via a custom error handler
- return consistent JSON responses for both success and failure scenarios, including forwarding responses when successful

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e67c97a1c0832daf61c0d14f4c30f0